### PR TITLE
don't load template twice

### DIFF
--- a/classes/client-fixed-quantity-price.php
+++ b/classes/client-fixed-quantity-price.php
@@ -418,7 +418,7 @@ if (!class_exists('WooClientFixedQuantity')) {
             
             // search template in theme
             $theme_plugin_template = 'woocommerce-fixed-quantity/' . $template_name;
-            $template = locate_template($theme_plugin_template, $require_once);
+            $template = locate_template($theme_plugin_template, false, $require_once);
             
             if (!$template) {
                 // get default template


### PR DESCRIPTION
https://developer.wordpress.org/reference/functions/locate_template/
require_once is the third param of locate_template not the second so if the template is overriden this one is outputed instead twice
